### PR TITLE
Improve exception handling

### DIFF
--- a/src/PluginAvailabilityPlugin.php
+++ b/src/PluginAvailabilityPlugin.php
@@ -4,15 +4,16 @@ namespace Required\ComposerScripts;
 
 use Composer\Composer;
 use Composer\DependencyResolver\Operation\InstallOperation;
+use Composer\Downloader\TransportException;
 use Composer\EventDispatcher\EventSubscriberInterface;
+use Composer\Factory;
 use Composer\Installer\PackageEvent;
 use Composer\IO\IOInterface;
 use Composer\Package\PackageInterface;
 use Composer\Plugin\PluginInterface;
 use Composer\Installer\PackageEvents;
+use Composer\Util\RemoteFilesystem;
 use DateTime;
-use ErrorException;
-use Required\ComposerScripts\WordPressPluginHelper;
 
 class PluginAvailabilityPlugin implements PluginInterface, EventSubscriberInterface {
 	/** @var Composer */
@@ -24,9 +25,13 @@ class PluginAvailabilityPlugin implements PluginInterface, EventSubscriberInterf
 	/** @var WordPressPluginHelper */
 	private $helper;
 
+	/** @var RemoteFilesystem */
+	private $rfs;
+
 	public function activate( Composer $composer, IOInterface $io ) {
 		$this->composer = $composer;
 		$this->io       = $io;
+		$this->rfs      = Factory::createRemoteFilesystem( $this->io );
 		$this->helper   = new WordPressPluginHelper();
 	}
 
@@ -54,11 +59,17 @@ class PluginAvailabilityPlugin implements PluginInterface, EventSubscriberInterf
 	public function checkAvailability( PackageEvent $event ) {
 		$package = $this->getPackage( $event );
 
-		if ( $this->helper->isWordPressPlugin( $package ) && ! $this->isPluginAvailable( $this->helper->getPluginApiURL( $package ) ) ) {
-			$this->io->writeError( sprintf(
-				'<warning>The plugin %s does not seem to be available in the WordPress Plugin Directory anymore.</warning>',
-				$package->getName()
-			) );
+		try {
+			if ( $this->helper->isWordPressPlugin( $package ) && ! $this->isPluginAvailable( $this->helper->getPluginApiURL( $package ) ) ) {
+				$this->io->writeError( sprintf(
+					'<warning>The plugin %s does not seem to be available in the WordPress Plugin Directory anymore.</warning>',
+					$package->getName()
+				) );
+			}
+		} catch ( TransportException $e ) {
+			$this->io->writeError(
+				'<warning>Could not reach WordPress.org to verify plugin availability status.</warning>'
+			);
 		}
 	}
 
@@ -73,11 +84,17 @@ class PluginAvailabilityPlugin implements PluginInterface, EventSubscriberInterf
 	public function checkMaintenanceStatus( PackageEvent $event ) {
 		$package = $this->getPackage( $event );
 
-		if ( $this->helper->isWordPressPlugin( $package ) && ! $this->isPluginActivelyMaintained( $this->helper->getPluginApiURL( $package ) ) ) {
-			$this->io->writeError( sprintf(
-				'<warning>The plugin %s has not been updated in over two years. Please double-check before using it.</warning>',
-				$package->getName()
-			) );
+		try {
+			if ( $this->helper->isWordPressPlugin( $package ) && ! $this->isPluginActivelyMaintained( $this->helper->getPluginApiURL( $package ) ) ) {
+				$this->io->writeError( sprintf(
+					'<warning>The plugin %s has not been updated in over two years. Please double-check before using it.</warning>',
+					$package->getName()
+				) );
+			}
+		} catch ( TransportException $e ) {
+			$this->io->writeError(
+				'<warning>Could not reach WordPress.org to verify plugin availability status.</warning>'
+			);
 		}
 	}
 
@@ -96,53 +113,51 @@ class PluginAvailabilityPlugin implements PluginInterface, EventSubscriberInterf
 	/**
 	 * Determines whether a plugin is available in the WordPress Plugin Directory.
 	 *
+	 * @throws TransportException
+	 *
 	 * @param string $url URL to the plugin in the WordPress Plugin Directory.
 	 *
 	 * @return bool True if the plugin is available, false if otherwise (404 status).
 	 */
 	protected function isPluginAvailable( $url ) {
-		try {
-			$result = $this->loadPluginData( $url );
+		$result = $this->loadPluginData( $url );
 
-			return null !== $result;
-		} catch ( ErrorException $e ) {
-			return false;
-		}
+		return ! isset( $result['error'] );
 	}
 
 	/**
 	 * Determines whether a plugin is actively maintained or not.
+	 *
+	 * @throws TransportException
 	 *
 	 * @param string $url URL to the plugin in the WordPress Plugin Directory.
 	 *
 	 * @return bool True if the plugin has been updated in the last two years, false otherwise.
 	 */
 	protected function isPluginActivelyMaintained( $url ) {
-		try {
-			$result = $this->loadPluginData( $url );
+		$result = $this->loadPluginData( $url );
 
-			if ( null === $result ) {
-				return false;
-			}
-
-			$now          = new DateTime();
-			$last_updated = new DateTime( $result['last_updated'] );
-
-			return $last_updated > $now->modify( '-2 years' );
-		} catch ( ErrorException $e ) {
+		if ( null === $result || isset( $result['error'] ) ) {
 			return false;
 		}
+
+		$now          = new DateTime();
+		$last_updated = new DateTime( $result['last_updated'] );
+
+		return $last_updated > $now->modify( '-2 years' );
 	}
 
 	/**
 	 * Loads data for a given plugin and tries to interpret the result as JSON.
+	 *
+	 * @throws TransportException
 	 *
 	 * @param string $url Plugin URL.
 	 *
 	 * @return array|null Plugin data on success, null on failure.
 	 */
 	protected function loadPluginData( $url ) {
-		$result = file_get_contents( $url );
+		$result = $this->rfs->getContents( $url, $url, false );
 
 		$result = json_decode( $result, true );
 


### PR DESCRIPTION
This PR:

* accounts for the fact that the API returns a JSON object with an error property when a plugin is not available.
* Uses Composer's `RemoteFileSystem` class to handle downloads. It does retries, exception handling, etc.
* Displays a warning when getting a `TransportException` (which likely occurs when w.org is down).

To do:

* Allow passing `RemoteFileSystem` via constructor so we can use `RemoteFilesystemMock` in tests and verify the correctness of this functionality.
* Maybe only print this warning once, ideally after all updates/installs went through.

See #5.